### PR TITLE
abort with a 404 when no info found

### DIFF
--- a/devpi_json_info/devpi_json_info.py
+++ b/devpi_json_info/devpi_json_info.py
@@ -1,4 +1,5 @@
 from devpi_common.url import URL
+from devpi_server.views import abort
 from devpi_server.readonly import get_mutable_deepcopy
 from pluggy import HookimplMarker
 from pyramid.view import view_config
@@ -29,6 +30,8 @@ def json_info_view(context, request):
     baseurl = URL(request.application_url).asdir()
     version = context.stage.get_latest_version(context.project, stable=True)
     info = get_mutable_deepcopy(context.stage.get_versiondata(context.project, version))
+    if not info:
+        abort(request, 404, 'no info found')
     info.pop("+elinks", None)
     result = dict(info=info, releases={})
     for release in context.stage.get_releaselinks(context.project):


### PR DESCRIPTION
This follow the behavior of [PyPI.org](https://pypi.org) when the package doesn't exist.

For example, this is useful when using [pipreqs](https://github.com/bndr/pipreqs) to generate some requirements.txt, currently if a package doesn't exist this will return:  
```
{
  "info": {},
  "releases": {}
}
```
(In the case of pipreqs, this will make it crash while looking for a `version` in `info`)

The correct behavior (i.e mirroring pypi) would be to return a 404.
[Example of PyPI.org returning 404](https://pypi.org/pypi/thispackagedoesntexist/json/)
[Example of PyPI.org returning json info](https://pypi.org/pypi/netifaces/json/)